### PR TITLE
Add smart weight: a better way to balance classification probabilities

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -36,3 +36,18 @@ RSpec/ExampleLength:
 # For strings I enjoy using %w[], but for symbols the %i[] syntax just does not click.
 Style/SymbolArray:
   EnforcedStyle: brackets
+
+# Indentation is something I've got strong opinions about which differ from Rubocop.
+Layout/ArgumentAlignment:
+  EnforcedStyle: with_fixed_indentation # default is with_first_argument
+Layout/ArrayAlignment:
+  EnforcedStyle: with_fixed_indentation # default is with_first_element
+Layout/FirstArgumentIndentation:
+  EnforcedStyle: consistent # default is special_for_inner_method_call_in_parentheses
+Layout/FirstArrayElementIndentation:
+  EnforcedStyle: consistent # default is special_inside_parentheses
+Layout/FirstHashElementIndentation:
+  EnforcedStyle: consistent # default is special_inside_parentheses
+# Let's enforce this to be consistent
+Layout/EndOfLine:
+  EnforcedStyle: lf # \n (unix line end) enforced everywhere, default is native

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 The next release will be 0.5.0 due to a breaking change: removal of code that was deprecated in 0.4.0.
 
 - Breaking: remove `String#tokenize` core extension; please use `Groupie.tokenize(string)` instead
+- Breaking: due to changed internals, YAML serialized data from 0.4.x will lack some of the new internal caches. I'd suggest loading the old data and adding the words from each group to a new (0.5.x) instance of Groupie.
 - Feat: add support for smart default weights, reducing the effect of low data on predictions
 - Deps: add Ruby 3.1 to list of tested & supported gems
 - Chore: require multi-factor authentication to publish gem updates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 The next release will be 0.5.0 due to a breaking change: removal of code that was deprecated in 0.4.0.
 
 - Breaking: remove `String#tokenize` core extension; please use `Groupie.tokenize(string)` instead
+- Feat: add support for smart default weights, reducing the effect of low data on predictions
 - Deps: add Ruby 3.1 to list of tested & supported gems
 - Chore: require multi-factor authentication to publish gem updates
 - Chore: add Security.md to advertise a security policy

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in groupie.gemspec
 gemspec
 
+gem 'psych', '~> 4.0'
 gem 'rake', '~> 13.0'
 gem 'rspec', '~> 3.0'
 gem 'rubocop', '~> 1.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,6 +11,8 @@ GEM
     parallel (1.21.0)
     parser (3.1.0.0)
       ast (~> 2.4.1)
+    psych (4.0.3)
+      stringio
     rainbow (3.1.1)
     rake (13.0.6)
     regexp_parser (2.2.1)
@@ -47,6 +49,7 @@ GEM
     rubocop-rspec (2.8.0)
       rubocop (~> 1.19)
     ruby-progressbar (1.11.0)
+    stringio (3.0.1)
     unicode-display_width (2.1.0)
 
 PLATFORMS
@@ -56,6 +59,7 @@ PLATFORMS
 
 DEPENDENCIES
   groupie!
+  psych (~> 4.0)
   rake (~> 13.0)
   rspec (~> 3.0)
   rubocop (~> 1.7)

--- a/README.md
+++ b/README.md
@@ -92,6 +92,21 @@ groupie.classify_text(test_tokens, :unique)
 test_tokens - (test_tokens & groupie.unique_words)
 # => ["please", "to", "reset", "awesome"]
 # If you'd be classifying email, you can assume that common email headers will get ignored this way.
+
+# If you're just starting out, your incomplete data could lead to dramatic misrepresentations of the data.
+# To balance against this, you can enable smart weight:
+groupie.smart_weight = true
+# You could also set it during initialization via Groupie.new(smart_weight: true)
+# What's so useful about it? It adds a default weight to _all_ words, even the ones you haven't
+# seen yet, which counter-acts the data you have. This shines in low data situations,
+# reducing the impact of the few words you have seen before.
+groupie.default_weight
+# => 1.2285714285714286
+# Classifying the same text as before should consider all words, and add this default weight to all words
+# It basically gives all groups the likelihood of "claiming" a word,
+# unless there is strong data to suggest otherwise.
+groupie.classify_text(test_tokens)
+# => {:spam=>0.5241046831955923, :ham=>0.4758953168044077}
 ```
 
 Persistence can be naively done by using YAML:
@@ -112,7 +127,9 @@ For I'm still experimenting with Groupie in [Infinity Feed](https://www.infinity
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment. Rubocop is available via `bin/rubocop` with some friendly default settings.
 
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and the created tag, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+To install this gem onto your local machine, run `bundle exec rake install`.
+
+To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and the created tag, and push the `.gem` file to [rubygems.org](https://rubygems.org). For obvious reasons, only the project maintainer can do this.
 
 ## Contributing
 

--- a/lib/groupie.rb
+++ b/lib/groupie.rb
@@ -107,16 +107,15 @@ class Groupie
   #
   # @return [Float] The default weight for all words
   def default_weight
+    # Default weight only applies when smart weight is enabled
     return 0.0 unless smart_weight
 
-    # Find all unique words and the total count of all words
-    total_words = 0
-    @groups.each_value do |group|
-      total_words += group.total_word_count
-    end
-    total_unique_words = @known_words.count
-    return 0.0 unless total_unique_words.positive?
+    # If we don't know any words, the weight is also zero
+    return 0.0 unless @known_words.any?
 
+    # Gather counts and calculate
+    total_words = @groups.each_value.sum(&:total_word_count)
+    total_unique_words = @known_words.count
     total_words / total_unique_words.to_f
   end
 

--- a/lib/groupie.rb
+++ b/lib/groupie.rb
@@ -37,7 +37,7 @@ class Groupie
   # @param [Object] group The name of the group to access.
   # @return [Groupie::Group] An existing or new group identified by +group+.
   def [](group)
-    @groups[group] ||= Group.new(group)
+    @groups[group] ||= Group.new(group, self)
   end
 
   # Classify a text by taking the average of all word classifications.
@@ -112,10 +112,8 @@ class Groupie
     total_words = 0
     unique_words = Set.new
     @groups.each_value do |group|
-      group.word_counts.each do |word, count|
-        unique_words << word
-        total_words += count
-      end
+      unique_words += group.words
+      total_words += group.total_word_count
     end
     total_unique_words = unique_words.count
     return 0.0 unless total_unique_words.positive?

--- a/lib/groupie.rb
+++ b/lib/groupie.rb
@@ -15,6 +15,7 @@ class Groupie
   def initialize(smart_weight: false)
     @groups = {}
     @smart_weight = smart_weight
+    @known_words = Set.new
   end
 
   # Turn a String (or anything else that responds to #to_s) into an Array of String tokens.
@@ -110,15 +111,18 @@ class Groupie
 
     # Find all unique words and the total count of all words
     total_words = 0
-    unique_words = Set.new
     @groups.each_value do |group|
-      unique_words += group.words
       total_words += group.total_word_count
     end
-    total_unique_words = unique_words.count
+    total_unique_words = @known_words.count
     return 0.0 unless total_unique_words.positive?
 
     total_words / total_unique_words.to_f
+  end
+
+  # Private method used by Groups to register known words with the Group.
+  def add_word(word)
+    @known_words << word
   end
 
   private

--- a/lib/groupie/group.rb
+++ b/lib/groupie/group.rb
@@ -3,11 +3,13 @@
 class Groupie
   # Group represents a group or category that words can be classified into.
   class Group
-    attr_reader :word_counts
+    attr_reader :word_counts, :total_word_count
 
-    def initialize(name)
+    def initialize(name, groupie)
       @name = name
+      @groupie = groupie
       @word_counts = {}
+      @total_word_count = 0
     end
 
     def words
@@ -35,6 +37,7 @@ class Groupie
     def add_word(word)
       @word_counts[word] ||= 0
       @word_counts[word] += 1
+      @total_word_count += 1
     end
   end
 end

--- a/lib/groupie/group.rb
+++ b/lib/groupie/group.rb
@@ -36,8 +36,11 @@ class Groupie
     # Add a single word and count it.
     def add_word(word)
       @word_counts[word] ||= 0
-      @word_counts[word] += 1
+      current_count = @word_counts[word] += 1
       @total_word_count += 1
+      # If this word is new for this Group, it might be new for the entire Groupie
+      @groupie.add_word(word) if current_count == 1
+      nil
     end
   end
 end

--- a/spec/groupie/group_spec.rb
+++ b/spec/groupie/group_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'yaml'
 
 RSpec.describe Groupie::Group do
   let(:group) { Groupie::Group.new('test') }
@@ -25,13 +24,5 @@ RSpec.describe Groupie::Group do
     it 'is aliased as <<' do
       group.method(:add).should == group.method(:<<)
     end
-  end
-
-  it 'can be serialized and loaded through YAML' do
-    group = Groupie::Group.new 'group'
-    group.add %w[buy flowers]
-    loaded_group = YAML.safe_load(group.to_yaml, permitted_classes: [Groupie::Group])
-    loaded_group.add %w[buy candy]
-    loaded_group.count('candy').should == 1
   end
 end

--- a/spec/groupie/group_spec.rb
+++ b/spec/groupie/group_spec.rb
@@ -3,7 +3,8 @@
 require 'spec_helper'
 
 RSpec.describe Groupie::Group do
-  let(:group) { Groupie::Group.new('test') }
+  let(:groupie) { Groupie.new }
+  let(:group) { Groupie::Group.new('test', groupie) }
 
   describe '#add' do
     it 'accepts a single string' do
@@ -23,6 +24,12 @@ RSpec.describe Groupie::Group do
 
     it 'is aliased as <<' do
       group.method(:add).should == group.method(:<<)
+    end
+
+    it 'increases total_word_count by the number of words' do
+      expect do
+        group.add(%w[one two three])
+      end.to change(group, :total_word_count).from(0).to(3)
     end
   end
 end

--- a/spec/groupie_spec.rb
+++ b/spec/groupie_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'yaml'
+require 'psych'
 
 RSpec.describe Groupie do
   it 'has a version' do
@@ -286,7 +286,9 @@ RSpec.describe Groupie do
     groupie['one'].add %w[buy flowers]
     groupie['two'].add %w[buy roses]
 
-    loaded = YAML.unsafe_load(YAML.dump(groupie))
+    # Use Psych via a Gem to have a consistent library interface vs older versions in older Ruby versions
+    yaml = Psych.dump(groupie)
+    loaded = Psych.safe_load(yaml, aliases: true, permitted_classes: [Groupie, Groupie::Group, Set])
 
     expect(loaded.classify_text(%w[buy candy])).to eq(groupie.classify_text(%w[buy candy]))
   end

--- a/spec/groupie_spec.rb
+++ b/spec/groupie_spec.rb
@@ -220,4 +220,63 @@ RSpec.describe Groupie do
       Groupie.tokenize('"first last"').should == %w[first last]
     end
   end
+
+  describe 'when smart_weight is enabled' do
+    let(:groupie) { Groupie.new smart_weight: true }
+
+    describe '#default_weight' do
+      it 'returns 0.0 by default' do
+        expect(groupie.default_weight).to eq(0.0)
+      end
+
+      it 'returns the average frequency of unique words' do
+        groupie[:one].add %w[test test groupie]
+        # 3 words / 2 unique words = 1.5
+        expect(groupie.default_weight).to eq(1.5)
+      end
+
+      it 'combines the results from all groups' do
+        groupie[:one].add %w[test test]
+        groupie[:two].add %w[test two]
+        # 4 total occurrences divided by 2 unique words
+        expect(groupie.default_weight).to eq(2.0)
+      end
+    end
+
+    describe '#classify' do
+      it 'gives new words equal weighting across groups' do
+        groupie[:one].add %w[one]
+        groupie[:two].add %w[two]
+        expect(groupie.classify('new')).to eq({ one: 0.5, two: 0.5 })
+      end
+
+      it 'adds default_weight to all word counts prior to applying the strategy' do
+        groupie[:one].add %w[one]
+        groupie[:two].add %w[two]
+        # sum strategy adds the word count to the default weight (1) and divides by the total weight (3)
+        expect(groupie.classify('one')).to eq({ one: 2 / 3.0, two: 1 / 3.0 })
+      end
+    end
+
+    describe '#classify_text' do
+      it 'gives new words equal weighting across groups' do
+        groupie[:one].add %w[one]
+        groupie[:two].add %w[two]
+        # Classify text with one word is basically a less efficient classify()
+        expect(groupie.classify_text(%w[new])).to eq({ one: 0.5, two: 0.5 })
+      end
+
+      it 'adds default_weight to all word counts prior to applying the strategy' do
+        groupie[:one].add %w[one]
+        groupie[:two].add %w[two]
+        # Sum strategy for each word, and then we average the results for each group
+        # - new should get 1/2 in each group
+        # - one should get 2/3 in group one, and 1/3 in group two
+        expect(groupie.classify_text(%w[new one])).to eq({
+                                                           one: ((2 / 3.0) + (1 / 2.0)) / 2.0,
+                                                           two: ((1 / 3.0) + (1 / 2.0)) / 2.0
+                                                         })
+      end
+    end
+  end
 end

--- a/spec/groupie_spec.rb
+++ b/spec/groupie_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'yaml'
 
 RSpec.describe Groupie do
   it 'has a version' do
@@ -278,5 +279,15 @@ RSpec.describe Groupie do
         })
       end
     end
+  end
+
+  it 'can be serialized and loaded through YAML' do
+    groupie = Groupie.new
+    groupie['one'].add %w[buy flowers]
+    groupie['two'].add %w[buy roses]
+
+    loaded = YAML.unsafe_load(YAML.dump(groupie))
+
+    expect(loaded.classify_text(%w[buy candy])).to eq(groupie.classify_text(%w[buy candy]))
   end
 end

--- a/spec/groupie_spec.rb
+++ b/spec/groupie_spec.rb
@@ -273,9 +273,9 @@ RSpec.describe Groupie do
         # - new should get 1/2 in each group
         # - one should get 2/3 in group one, and 1/3 in group two
         expect(groupie.classify_text(%w[new one])).to eq({
-                                                           one: ((2 / 3.0) + (1 / 2.0)) / 2.0,
-                                                           two: ((1 / 3.0) + (1 / 2.0)) / 2.0
-                                                         })
+          one: ((2 / 3.0) + (1 / 2.0)) / 2.0,
+          two: ((1 / 3.0) + (1 / 2.0)) / 2.0
+        })
       end
     end
   end


### PR DESCRIPTION
## What problem does this address?

Without smart weight your classification (and prediction) is strongly biased when you have very limited data. You see a word once and it becomes a "100% guarantee" that the word means a specific categorization.

## How does this PR address the issue?

It introduces a new option for Groupie: smart weight, which can be enabled during initialization (`Groupie.new(smart_weight: true)`) or after the fact (`groupie.smart_weight = true`).

Once this setting is enabled, each classification will _always_ add a new `default_weight` value to each word's count prior to applying the score strategy, whether we've seen the word before or not.

The effect is instant: each new (never classified) word is now considered to have an equal probability to be in one of your categories due to each category having a `default_weight` that balances out. By classifying more words, you simply add more weight to one or more of the categories, tipping the balance away from the default equilibrium.

This means you need more data to more strongly shift the balance between categories, which is usually a good thing.

The `default_weight` value is dynamic. It's the number of unique words divided by the total count of words categorized. This means it scales along with the size of your dataset and thus balances out words with low frequency: it's hard to tell if they are a true signal or just a fluke.

## Breaking changes

In order to perform these calculations in a smart (i.e. fast) way, I've ended up refactoring a bunch of the internals. Two important ones are that `Groupie::Group`s now have a link back to their `Groupie` instance and that both classes keep extra data to track unique words and total word counts. An unfortunate side-effect is that old YAML-serialized data won't be drop-in compatible due to lacking some of this data.

I think that loading old data and adding all words to a new instance of Groupie will probably work. Due to this being an old gem that's mostly for my own usage (and I'm not serializing any data yet, so this is not a problem for me), I'm content to leave this as a warning and an exercise for whomever needs it.

## History & details

The initial implementation. It proves the concept, but is rough and inefficient. I started with the Readme, prototyping the API I wanted, then specs, then the code. Rubocop was _not_ happy about the added complexity, so cleanup was required.

- Feat: add smart weight support (c80b50c)

Rubocop style update to make it not perform huge indentations.

- Style: apply a few layout rules regarding indentation (a471f58)

I realized that in order to make things better, I could not let Groups be fully independent classes. Newly added words needed to be tracked centrally in `Groupie` itself. It felt useful to start with moving the serialization test to Groupie, before I started making changes to Group.

- Test: moved serialization spec from Groupie::Group to Groupie (c8a02ad)

Track local data in Group, so we don't have to do this in `default_weight`. This eliminates having to loop over each unique word in each category. A side effect of tracking more internal data this way is that it breaks functionality of old serialized data.

- Change: Groups track their total word count (a8ee866)

More refactoring passes that build on top of the previous change: have Groupie track all unique words it knows about, so we only have to count that Set rather than first building the Set in order to count it.

- Refactor: Groupie tracks known words to speedup default_weight (cfcfcf6)

Next is cleaning up the implementation of `default_weight` because the new tools allow this.

- Refactor: simplified Groupie#default_weight (2f720a0)

Lastly I'm addressing Rubocop's (correct) assessment that Groupie#classify was horribly complex. Re-implementing it led to a cleaner approach using the tools we have.

- Refactor: Groupie#classify internals are simpler (b4ed9a1)

Pushing the code to Github to test on older Ruby versions exposed an interface inconsistency in the built-in YAML library, so I've added Psych as a dev dependency to work around this. I'm testing YAML as a courtesy, not as a fully embraced feature (yet).

- Specfix: switch to Psych for YAML test (09f5f74)


As the force push in the history of this PR shows, I've performed a few interactive rebase fixups to correct some things in earlier commits.