### PR TITLE
Improve url tokenization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased changes
 
+- Feat: add better tokenization support for URIs.
+
 ## Version 0.5.0 -- 2022-02-16
 
 This release has breaking changes (deprecation cleanup and internals rework), a new feature (smart weights!) and is officially tested on Ruby 3.1.0 (it's what I use). I've enabled the setting to require MFA to publish this gem, to help protect those who use it.

--- a/lib/groupie.rb
+++ b/lib/groupie.rb
@@ -27,9 +27,18 @@ class Groupie
     object
       .to_s
       .downcase
-      .gsub(/\s/, ' ')
+      .gsub(/\s+/, ' ')
       .gsub(/[$']/, '')
-      .gsub(/<[^>]+?>|[^\w -.,]/, '')
+      .gsub(/<[^>]+?>/, ' ')
+      .gsub(%r{http[\w\-\#:/_.?&=]+}) do |url|
+        uri = URI.parse(url)
+        path = uri.path.to_s.tr('/_\-', ' ')
+        query = uri.query.to_s.tr('?=&#_\-', ' ')
+        fragment = uri.fragment.to_s.tr('#_/\-', ' ')
+        split = "#{uri.scheme} #{uri.host} #{path} #{query} #{fragment}"
+        split
+      end
+      .gsub(/[^\w -.,]/, ' ')
       .split.map { |str| str.gsub(/\A['"]+|[!,."']+\Z/, '') }
   end
 

--- a/lib/groupie.rb
+++ b/lib/groupie.rb
@@ -2,6 +2,7 @@
 
 require_relative 'groupie/version'
 require_relative 'groupie/group'
+require_relative 'groupie/tokenizer'
 require 'set'
 
 # Groupie is a text grouper and classifier, using naive Bayesian filtering.
@@ -24,33 +25,7 @@ class Groupie
   # @param [String, #to_s] object
   # @return [Array<String>]
   def self.tokenize(object)
-    # Ensure our object is converted to a String and duplicated so we can modify it in-place
-    object = object.to_s.dup
-    # Ignore case by downcasing everything
-    object.downcase!
-    # Convert all types of whitespace (space, tab, newline) into regular spaces
-    object.gsub!(/\s+/, ' ')
-    # Strip HTML tags entirely
-    object.gsub!(/<[^>]+?>/, ' ')
-    # Intelligently split URLs into their component parts
-    object.gsub!(%r{http[\w\-\#:/_.?&=]+}) do |url|
-      uri = URI.parse(url)
-      path = uri.path.to_s
-      path.tr!('/_\-', ' ')
-      query = uri.query.to_s
-      query.tr!('?=&#_\-', ' ')
-      fragment = uri.fragment.to_s
-      fragment.tr!('#_/\-', ' ')
-      "#{uri.scheme} #{uri.host} #{path} #{query} #{fragment}"
-    end
-    # Strip characters not likely to be part of a word or number
-    object.gsub!(/[^\w\ \-.,]/, ' ')
-    # Split the resulting string on whitespace
-    object.split.map do |str|
-      # Final cleanup of wrapped quotes and interpunction
-      str.gsub!(/\A['"]+|[!,."']+\Z/, '')
-      str
-    end
+    Tokenizer.new(object).to_tokens
   end
 
   # Access an existing Group or create a new one.

--- a/lib/groupie/tokenizer.rb
+++ b/lib/groupie/tokenizer.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'uri'
+
+class Groupie
+  # Tokenizer helps turn a String into an Array of Strings that are the
+  # individual tokens (mostly words) from the input.
+  #
+  # Please consider this entire class to be a private API,
+  # and use Groupie.tokenize to tokenize things.
+  class Tokenizer
+    def initialize(input)
+      # Ensure our input is converted to a String and duplicated so we can modify it in-place
+      @raw = input.to_s.dup
+    end
+
+    def to_tokens
+      return @tokens if @tokens
+
+      # Ignore case by downcasing everything
+      @raw.downcase!
+      # Convert all types of whitespace (space, tab, newline) into regular spaces
+      @raw.gsub!(/\s+/, ' ')
+      # Strip HTML tags entirely
+      @raw.gsub!(/<[^>]+?>/, ' ')
+      # Intelligently split URLs into their component parts
+      @raw.gsub!(%r{http[\w\-\#:/_.?&=]+}) do |url|
+        uri = URI.parse(url)
+        path = uri.path.to_s
+        path.tr!('/_\-', ' ')
+        query = uri.query.to_s
+        query.tr!('?=&#_\-', ' ')
+        fragment = uri.fragment.to_s
+        fragment.tr!('#_/\-', ' ')
+        "#{uri.scheme} #{uri.host} #{path} #{query} #{fragment}"
+      end
+      # Strip characters not likely to be part of a word or number
+      @raw.gsub!(/[^\w\ \-.,]/, ' ')
+      # Split the resulting string on whitespace
+      @tokens = @raw.split.map do |str|
+        # Final cleanup of wrapped quotes and interpunction
+        str.gsub!(/\A['"]+|[!,."']+\Z/, '')
+        str
+      end
+
+      @tokens
+    end
+  end
+end

--- a/spec/groupie_spec.rb
+++ b/spec/groupie_spec.rb
@@ -220,6 +220,14 @@ RSpec.describe Groupie do
     it 'strips quotes around tokens' do
       Groupie.tokenize('"first last"').should == %w[first last]
     end
+
+    it 'extracts words from urls' do
+      expect(
+        Groupie.tokenize('https://example.org/blog-path/2022/1234-title-of-blog-post?custom=query&foo=bar#my-anchor')
+      ).to eq(
+        %w[https example.org blog path 2022 1234 title of blog post custom query foo bar my anchor]
+      )
+    end
   end
 
   describe 'when smart_weight is enabled' do


### PR DESCRIPTION
## What is the goal?

To extract more meaningful tokens from a URL.

## Examples please

Let's consider a URL that has most components in it:

```
https://example.org/blog-path/2022/1234-title-of-blog-post?custom=query&foo=bar#my-anchor
```

Old tokenization:

```ruby
["httpsexample.orgblog-path20221234-title-of-blog-postcustomquery&foobar#my-anchor"]
```

Improved tokenization:

```ruby
%w[https example.org blog path 2022 1234 title of blog post custom query foo bar my anchor]
```

## Details

I've intentionally kept the domain whole, but decided to split on special characters in the rest of the url.
After implementing this I refactored the `Groupie.tokenize` method to duplicate the input string once, after which we now use in-place modifiers to avoid generating a lot of new strings.

I'm not 100% convinced that the URI parser is the _best_ approach, but it's one that works well enough for now. In the future it might be useful to replace it with a gsub + Regexp solution that splits the URI scheme and domain, and tokenizes the rest more aggressively.

## History

Add a test + implementation:

- Feat: Groupie.tokenize breaks down urls more intelligently (cff2464)

Switch from a long chain of gsubs (which return new Strings) to destructive operations, also annotate the entire chain.

- Refactor: Groupie.tokenize modifies a duplicate string (9916dba)

Update the Changelog to indicate what happened.

- Doc: update Changelog (8f91405)

Address Rubocop's valid concerns that `Groupie.tokenize` was becoming too long and complex.
My goal was to split the method into intention-revealing helpers, but I did not want to pollute the `Groupie` class with this (single responsibility principle) so I extracted the logic to a new class, `Groupie::Tokenizer`, before I refactored it into helpers.

- Refactor: move tokenizer logic to Groupie::Tokenizer (b796424)
- Refactor: split Tokenizer into helper methods (85efeed)
