### PR TITLE
Fix invalid url raising error during Groupie.tokenize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased changes
 
-- Feat: add better tokenization support for URIs.
+- Feat: add better tokenization support for URIs ([#42](https://github.com/Narnach/groupie/pull/42), [#44](https://github.com/Narnach/groupie/pull/44))
 
 ## Version 0.5.0 -- 2022-02-16
 

--- a/lib/groupie/tokenizer.rb
+++ b/lib/groupie/tokenizer.rb
@@ -51,6 +51,9 @@ class Groupie
     def tokenize_urls!
       @raw.gsub!(%r{http[\w\-\#:/_.?&=]+}) do |url|
         uri = URI.parse(url)
+      rescue URI::InvalidURIError
+        url
+      else
         path = uri.path.to_s
         path.tr!('/_\-', ' ')
         query = uri.query.to_s

--- a/spec/groupie_spec.rb
+++ b/spec/groupie_spec.rb
@@ -228,6 +228,10 @@ RSpec.describe Groupie do
         %w[https example.org blog path 2022 1234 title of blog post custom query foo bar my anchor]
       )
     end
+
+    it 'treats invalid URLs as plain text' do
+      expect(Groupie.tokenize('http://localhost:3000&amp')).to eq(%w[http localhost 3000 amp])
+    end
   end
 
   describe 'when smart_weight is enabled' do


### PR DESCRIPTION
# What's the problem?

An invalid URL-like String would cause `Groupie.tokenize` to raise `URI::InvalidURIError`.

## How to reproduce it?

```ruby
Groupie.tokenize('http://localhost:3000&amp')
```

## What's changed in the solution?

The input that resembles a URL but fails to parse is no longer treated like a real URL, but simply as text that's processed by the rest of the code.

- Fix: don't raise on invalid URIs (7fd1ad7)

Due to the added responsibility of handling this new concern (is the URL valid or not?) I've extracted a helper method that encapsulates the new behavior and condensed the old code (which improves readability to my eyes) to stay within the line count guidelines that Rubocop enforces by default.

- Refactor: condense `Tokenizer#tokenize_urls!` (c48148e)

The changelog now points to both PRs for this feature.

- Doc: update changelog (394c4cc)
