### PR TITLE
Drop Ruby 2.6; minimum becomes 2.7.0

### DIFF
--- a/.github/workflows/gem.yml
+++ b/.github/workflows/gem.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.0
+          ruby-version: 2.7
           bundler-cache: true
       - name: Build the gem
         run: bundle exec rake build

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -3,14 +3,14 @@ name: RSpec
 on: [ push, pull_request ]
 
 jobs:
-  build:
+  rspec:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # Maintained versions: 2.7, 3.0, 3.1
-        # Security updates only: 2.6 (EOL: 2022-03-31)
+        # Maintained versions: 3.0, 3.1
+        # Security updates only: 2.7 (expected EOL: 2023-03-31)
         # Source: https://www.ruby-lang.org/en/downloads/branches/
-        ruby: [ 2.6, 2.7, 3.0, 3.1 ]
+        ruby: [ 2.7, 3.0, 3.1 ]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Ruby

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -8,9 +8,9 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3
       - name: Install Ruby & Gems
-        uses: ruby/setup-ruby@v1 # Uses .ruby-version as version input
+        uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.0
+          ruby-version: 2.7
           bundler-cache: true
       - name: Rubocop
         # https://github.com/reviewdog/action-rubocop

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased changes
 
+- Breaking: drop support for Ruby 2.6, minimum is 2.7 ([#58](https://github.com/Narnach/groupie/pull/58))
 - Feat: add better tokenization support for URIs ([#42](https://github.com/Narnach/groupie/pull/42), [#44](https://github.com/Narnach/groupie/pull/44))
 
 ## Version 0.5.0 -- 2022-02-16

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,4 +68,4 @@ DEPENDENCIES
   rubocop-rspec (~> 2.4)
 
 BUNDLED WITH
-   2.3.4
+   2.3.14

--- a/groupie.gemspec
+++ b/groupie.gemspec
@@ -13,7 +13,9 @@ Gem::Specification.new do |spec|
                      ' of one of the defined groups. Think of bayesian spam filters.'
   spec.homepage = 'https://github.com/Narnach/groupie'
   spec.license = 'MIT'
-  spec.required_ruby_version = '>= 2.6.0' # EOL for 2.6 is 2022-03-31, so support this as the minimum for now
+  # Ruby maintains support for the last 3-4 minor versions, so that's what we do as well.
+  # See: https://www.ruby-lang.org/en/downloads/branches/
+  spec.required_ruby_version = '>= 2.7.0'
 
   spec.metadata['homepage_uri'] = spec.homepage
   spec.metadata['source_code_uri'] = 'https://github.com/Narnach/groupie'


### PR DESCRIPTION
This aligns with Ruby's own maintenance policy. Ruby 2.6 is End Of Life per 12 April 2022.
Ruby 2.7.0 is likely to receive security updates until April 2023, so that's the lowest version we're targeting with groupie now.

All CI tools now use Ruby 2.7 (instead of 3.0) to stick with the minimum version. It's what Rubocop seems to prefer.
Tests target all supported versions, so that's now 2.7, 3.0 and 3.1.