### PR TITLE
CI: Rubocop ignores unsafe cops, hides info severity

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -21,6 +21,7 @@ jobs:
           github_token: ${{ secrets.github_token }}
           reporter: github-pr-review
           rubocop_version: gemfile
+          rubocop_flags: --display-only-fail-level-offenses --safe
           # Rely on Bundler-installed gems so don't install them again
           use_bundler: true
           skip_install: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,6 +18,7 @@ Lint/Void:
 
 # RSpec has a lot of blocks, so ignore this rule there
 Metrics/BlockLength:
+  Severity: info
   Exclude:
     - 'spec/**/*_spec.rb'
 
@@ -27,10 +28,12 @@ RSpec/DescribedClass:
 
 # I prefer groups for structure, so the defaults are a little too strict for me
 RSpec/NestedGroups:
+  Severity: info
   Max: 4
 
 # I prefer more verbose examples, so tend to use more lines than the defaults
 RSpec/ExampleLength:
+  Severity: info
   Max: 20
 
 # For strings I enjoy using %w[], but for symbols the %i[] syntax just does not click.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Breaking: drop support for Ruby 2.6, minimum is 2.7 ([#58](https://github.com/Narnach/groupie/pull/58))
 - Feat: add better tokenization support for URIs ([#42](https://github.com/Narnach/groupie/pull/42), [#44](https://github.com/Narnach/groupie/pull/44))
+- Dev: Rubocop ignores unsafe cops, hides info severity ([#59](https://github.com/Narnach/groupie/pull/59))
 
 ## Version 0.5.0 -- 2022-02-16
 

--- a/bin/rubocop
+++ b/bin/rubocop
@@ -1,2 +1,15 @@
 #!/bin/bash
-bundle exec rubocop --force-exclusion $*
+# Run Rubocop with sane defaults
+# - only recognized file types: allows you to pipe in anything and have Ruboop only check files it thinks it can handle
+# - force exclusion: even when piping in files, it still ignores what I should not touch
+# - display style guide: help figure out what a rule is supposed to do
+# - safe: don't run experimental cops
+# - display only fail level offenses: hides INFO severity failing cops
+
+bundle exec rubocop \
+  --only-recognized-file-types \
+  --force-exclusion \
+  --display-style-guide \
+  --safe \
+  --display-only-fail-level-offenses \
+  $*


### PR DESCRIPTION
Info is not a violation, but will show up as a suggestion in IDE tooling, which is the way I prefer it.
Some of the cops with custom values are lowered to info severity to match their "suggestion" status.